### PR TITLE
radio: Plex sonic instant-mix via /nearest

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
         "publish:win-arm64:alpha": "pnpm run build && electron-builder --config electron-builder-alpha.yml --publish always --win --arm64",
         "publish:win-arm64:beta": "pnpm run build && electron-builder --config electron-builder-beta.yml --publish always --win --arm64",
         "start": "electron-vite preview",
+        "test": "vitest run",
+        "test:watch": "vitest",
         "typecheck": "pnpm run typecheck:node && pnpm run typecheck:web",
         "typecheck:node": "tsc --noEmit -p tsconfig.node.json --composite false",
         "typecheck:web": "tsc --noEmit -p tsconfig.web.json --composite false",
@@ -197,7 +199,8 @@
         "vite-plugin-conditional-import": "^0.1.7",
         "vite-plugin-dynamic-import": "^1.6.0",
         "vite-plugin-ejs": "^1.7.0",
-        "vite-plugin-pwa": "^1.3.0"
+        "vite-plugin-pwa": "^1.3.0",
+        "vitest": "^4.1.11"
     },
     "packageManager": "pnpm@11.5.2",
     "productName": "Feishin-plex"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -366,6 +366,9 @@ importers:
       vite-plugin-pwa:
         specifier: ^1.3.0
         version: 1.3.0(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.50.0)(yaml@2.9.0))(workbox-build@7.4.1(@types/babel__core@7.20.5))(workbox-window@7.4.1)
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@24.13.2)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.50.0)(yaml@2.9.0))
 
 packages:
 
@@ -2406,8 +2409,14 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/electron-localshortcut@3.1.3':
     resolution: {integrity: sha512-D+CRdDTRZ4/9UmcSaZ5qvW4uq2VyyVmqsH9cdNReB4CL6MSIgyhr9w2PKeNEb0J/ZS7db7irJM/+ZiA5uSQsLw==}
@@ -2535,6 +2544,35 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   '@vladfrangu/async_event_emitter@2.4.7':
     resolution: {integrity: sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==}
@@ -2678,6 +2716,10 @@ packages:
   asn1js@3.0.10:
     resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
     engines: {node: '>=12.0.0'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -2904,6 +2946,10 @@ packages:
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -3406,6 +3452,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -3535,6 +3584,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -3548,6 +3600,10 @@ packages:
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
@@ -4669,6 +4725,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -4777,6 +4837,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pause-stream@0.0.11:
     resolution: {integrity: sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==}
@@ -5347,6 +5410,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -5403,9 +5469,15 @@ packages:
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stat-mode@1.0.0:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -5633,6 +5705,9 @@ packages:
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -5640,6 +5715,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -5920,6 +5999,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -5976,6 +6096,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   win-guid@0.2.1:
@@ -8168,9 +8293,16 @@ snapshots:
       '@types/node': 24.13.2
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/electron-localshortcut@3.1.3':
     dependencies:
@@ -8336,6 +8468,47 @@ snapshots:
       vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.50.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.50.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.50.0)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   '@vladfrangu/async_event_emitter@2.4.7': {}
 
@@ -8535,6 +8708,8 @@ snapshots:
       pvtsutils: 1.3.6
       pvutils: 1.1.5
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
@@ -8788,6 +8963,8 @@ snapshots:
   caniuse-lite@1.0.30001799: {}
 
   caniuse-lite@1.0.30001809: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -9414,6 +9591,8 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  es-module-lexer@2.3.2: {}
+
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -9632,6 +9811,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   eta@4.6.0: {}
@@ -9651,6 +9834,8 @@ snapshots:
       bare-events: 2.9.1
     transitivePeerDependencies:
       - bare-abort-controller
+
+  expect-type@1.4.0: {}
 
   exponential-backoff@3.1.3: {}
 
@@ -9698,6 +9883,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
 
   file-entry-cache@11.1.3:
     dependencies:
@@ -10794,6 +10983,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.2
 
+  obug@2.1.4: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -10897,6 +11088,8 @@ snapshots:
       minipass: 7.1.3
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   pause-stream@0.0.11:
     dependencies:
@@ -11508,6 +11701,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -11559,7 +11754,11 @@ snapshots:
 
   sprintf-js@1.1.3: {}
 
+  stackback@0.0.2: {}
+
   stat-mode@1.0.0: {}
+
+  std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -11897,12 +12096,16 @@ snapshots:
 
   tiny-typed-emitter@2.1.0: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -12194,6 +12397,33 @@ snapshots:
       terser: 5.50.0
       yaml: 2.9.0
 
+  vitest@4.1.11(@types/node@24.13.2)(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.50.0)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@7.3.5(@types/node@24.13.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.50.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 7.3.5(@types/node@24.13.2)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.15))(terser@5.50.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.2
+    transitivePeerDependencies:
+      - msw
+
   void-elements@3.1.0: {}
 
   walk-sync@2.2.0:
@@ -12275,6 +12505,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   win-guid@0.2.1: {}
 

--- a/src/renderer/api/plex/plex-api.ts
+++ b/src/renderer/api/plex/plex-api.ts
@@ -909,6 +909,26 @@ export const pxApiClient = (args: {
             return response;
         },
 
+        // Sonic "instant mix": Plex's audio-analysis nearest-neighbour endpoint. Returns
+        // tracks ordered by sonic distance to the seed (closest first). Requires Plex Pass
+        // sonic analysis; servers without it return a non-200, which the caller degrades to
+        // an empty mix. The payload reuses the album-tracks Track shape - the extra per-track
+        // `distance` attribute is simply ignored by the schema.
+        getNearestTracks: async (
+            ratingKey: string,
+            params?: { limit?: number },
+        ): ApiResponse<PlexAlbumTracksResponse> => {
+            const response = await request<PlexAlbumTracksResponse>({
+                method: 'GET',
+                params: {
+                    limit: params?.limit,
+                },
+                path: `library/metadata/${ratingKey}/nearest`,
+            });
+
+            return response;
+        },
+
         getPlaylistList: async (): ApiResponse<PlexPlaylistListResponse> => {
             const response = await request<PlexPlaylistListResponse>({
                 method: 'GET',

--- a/src/renderer/api/plex/plex-controller.similar-songs.test.ts
+++ b/src/renderer/api/plex/plex-controller.similar-songs.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression test for the Plex sonic instant-mix.
+ *
+ * `getSimilarSongs` was a stub returning []; it now calls Plex's audio-analysis
+ * nearest-neighbour endpoint and maps the result to Songs. This locks that
+ * contract: the network boundary (`pxApiClient().getNearestTracks`) is mocked
+ * with the parsed-XML shape Plex actually returns, and the REAL controller
+ * transform + `pxNormalize.song` run against it.
+ */
+
+// Network boundary: control what the /nearest call returns.
+const getNearestTracks = vi.fn();
+vi.mock('/@/renderer/api/plex/plex-api', () => ({
+    pxApiClient: () => ({ getNearestTracks }),
+}));
+// Avoid pulling i18next init into the test (getSimilarSongs doesn't use it).
+vi.mock('/@/i18n/i18n', () => ({ default: { t: (key: string) => key } }));
+
+import { PlexController } from '/@/renderer/api/plex/plex-controller';
+
+const server = {
+    credential: 'TOKEN',
+    id: 'srv1',
+    type: 'plex',
+    url: 'https://music.fiber.house/plex',
+} as any;
+const apiClientProps = { server, signal: undefined } as any;
+
+// A Plex track in the shape the fork's XMLParser produces (attributes under `$`,
+// Track/Media/Part coerced to arrays by the parser's isArray config).
+const track = (ratingKey: string, title: string, distance: number, artist = 'Artist') => ({
+    $: {
+        distance: String(distance),
+        duration: '240000',
+        grandparentTitle: artist,
+        ratingKey,
+        title,
+        type: 'track',
+    },
+    Media: [
+        {
+            $: { audioChannels: '2', audioCodec: 'mp3', bitrate: '320', container: 'mp3' },
+            Part: [
+                {
+                    $: {
+                        container: 'mp3',
+                        key: `/library/parts/${ratingKey}/1/file.mp3`,
+                        size: '1000',
+                    },
+                },
+            ],
+        },
+    ],
+});
+const nearestBody = (tracks: unknown[]) => ({
+    MediaContainer: { $: { size: String(tracks.length) }, Track: tracks },
+});
+const call = (songId: string, count?: number) =>
+    (PlexController.getSimilarSongs as any)({ apiClientProps, query: { count, songId } });
+
+describe('PlexController.getSimilarSongs (sonic /nearest mix)', () => {
+    beforeEach(() => getNearestTracks.mockReset());
+
+    it('queries the sonic endpoint with the seed id + count and maps results in distance order', async () => {
+        getNearestTracks.mockResolvedValue({
+            body: nearestBody([
+                track('11', 'A', 0.1),
+                track('22', 'B', 0.12),
+                track('33', 'C', 0.14),
+            ]),
+            status: 200,
+        });
+
+        const songs = await call('99', 5);
+
+        expect(getNearestTracks).toHaveBeenCalledWith('99', { limit: 5 });
+        expect(songs.map((s: any) => s.id)).toEqual(['11', '22', '33']); // order preserved
+        expect(songs.map((s: any) => s.name)).toEqual(['A', 'B', 'C']);
+        expect(songs.every((s: any) => s._serverType === 'plex')).toBe(true);
+        // stream URL is built same-origin from SERVER_URL + Part.key + token
+        expect(songs[0].streamUrl).toBe(
+            'https://music.fiber.house/plex/library/parts/11/1/file.mp3?X-Plex-Token=TOKEN',
+        );
+    });
+
+    it('excludes the seed track when Plex includes it in the neighbours', async () => {
+        getNearestTracks.mockResolvedValue({
+            body: nearestBody([track('99', 'seed', 0.0), track('11', 'A', 0.1)]),
+            status: 200,
+        });
+
+        const songs = await call('99', 5);
+
+        expect(songs.map((s: any) => s.id)).toEqual(['11']);
+    });
+
+    it('degrades to [] when sonic analysis is unavailable (non-200)', async () => {
+        getNearestTracks.mockResolvedValue({ body: undefined, status: 404 });
+        expect(await call('99', 5)).toEqual([]);
+    });
+
+    it('returns [] for an empty MediaContainer (no Track element)', async () => {
+        getNearestTracks.mockResolvedValue({
+            body: { MediaContainer: { $: { size: '0' } } },
+            status: 200,
+        });
+        expect(await call('99', 5)).toEqual([]);
+    });
+
+    it('handles a single-track result without throwing', async () => {
+        getNearestTracks.mockResolvedValue({
+            body: nearestBody([track('11', 'A', 0.1)]),
+            status: 200,
+        });
+        const songs = await call('99', 1);
+        expect(songs).toHaveLength(1);
+        expect(songs[0].id).toBe('11');
+    });
+});

--- a/src/renderer/api/plex/plex-controller.ts
+++ b/src/renderer/api/plex/plex-controller.ts
@@ -1304,8 +1304,27 @@ export const PlexController: InternalControllerEndpoint = {
         };
     },
 
-    getSimilarSongs: async () => {
-        return [];
+    getSimilarSongs: async (args) => {
+        const { apiClientProps, query } = args;
+        const serverUrl = getPlexServerUrl(apiClientProps.server);
+        const token = getPlexToken(apiClientProps.server);
+
+        const apiClient = pxApiClient(apiClientProps);
+        const res = await apiClient.getNearestTracks(query.songId, {
+            limit: query.count,
+        });
+
+        // Plex's sonic analysis is a Plex Pass feature; servers without it return a
+        // non-200. Degrade to an empty mix rather than throwing, matching the prior stub.
+        if (res.status !== 200) {
+            return [];
+        }
+
+        const tracks = res.body?.MediaContainer?.Track ?? [];
+
+        return tracks
+            .filter((track) => track.$.ratingKey !== query.songId)
+            .map((track) => pxNormalize.song(track, apiClientProps.server, serverUrl, token));
     },
 
     getSongDetail: async (args) => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+// Minimal vitest setup mirroring the app's `/@/...` path aliases so unit tests
+// can import renderer/shared modules. Node environment - the units under test are
+// plain data-transform functions, no DOM.
+export default defineConfig({
+    resolve: {
+        alias: {
+            '/@/i18n': path.resolve(__dirname, './src/i18n'),
+            '/@/remote': path.resolve(__dirname, './src/remote'),
+            '/@/renderer': path.resolve(__dirname, './src/renderer'),
+            '/@/shared': path.resolve(__dirname, './src/shared'),
+        },
+    },
+    test: {
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+    },
+});

--- a/web.vite.config.ts
+++ b/web.vite.config.ts
@@ -137,7 +137,7 @@ export default defineConfig({
                 cleanupOutdatedCaches: true,
                 clientsClaim: true,
                 globIgnores: ['**/kuromoji/**'],
-                maximumFileSizeToCacheInBytes: 1000000 * 5, // 5 MB
+                maximumFileSizeToCacheInBytes: 1000000 * 8, // 8 MB
                 skipWaiting: true,
             },
         }),


### PR DESCRIPTION
## What

`getSimilarSongs` on the Plex controller was a stub returning `[]`. This implements it against Plex's audio-analysis nearest-neighbour endpoint (`library/metadata/{ratingKey}/nearest`), which returns tracks ordered by sonic distance to the seed, i.e. a Plexamp-style sonic mix. It powers the existing **Track radio** context action and the **Auto DJ** ("keep playing") song mode for Plex, both of which previously produced nothing on Plex.

## How

- `plex-api.ts`: add `getNearestTracks(ratingKey, { limit })` -> `GET library/metadata/{ratingKey}/nearest`. The response reuses the album-tracks `Track` shape, so the extra per-track `distance` attribute is simply ignored.
- `plex-controller.ts`: `getSimilarSongs` calls it, filters out the seed track, and maps via `pxNormalize.song`. Sonic analysis is a Plex Pass feature; servers without it return a non-200, which degrades to `[]` (matching the previous stub) rather than throwing.

## Also included (separable, happy to split if you'd rather take the feature alone)

- **Web build fix** (`build:`): the main app chunk now exceeds the 5 MB workbox `maximumFileSizeToCacheInBytes`, which fails `pnpm build:web` at service-worker generation. Raised to 8 MB.
- **Regression test** (`test(radio)`): adds `vitest` (there was no test runner) and locks the new contract: distance order preserved, seed excluded, non-200 -> `[]`, empty container -> `[]`, single-track result safe. Run with `pnpm test`.

## Verification

Tested live against a Plex Pass music server, deployed as the web build behind a reverse proxy:

- `/nearest` returns distance-ranked tracks (e.g. `0.099, 0.099, 0.121, 0.141`).
- mp3 and opus tracks both play; Track radio and Auto DJ produce sonic mixes.
- `pnpm lint`, `pnpm typecheck`, and `pnpm test` all pass; commits pass `commitlint`.

Commits are split (build / feat / test) for easy cherry-picking.
